### PR TITLE
Feat/dynamic wallpaper support

### DIFF
--- a/components/SettingsModal.qml
+++ b/components/SettingsModal.qml
@@ -602,6 +602,91 @@ Item {
                     }
                 }
 
+                Rectangle {
+                    id: rowAnim2
+                    Layout.fillWidth: true
+                    implicitHeight: 48
+                    radius: 4
+                    topLeftRadius: 4
+                    topRightRadius: 4
+                    bottomLeftRadius: 4
+                    bottomRightRadius: 4
+
+                    color: stateAnim2.containsMouse
+                        ? Colours.tPalette.m3surfaceContainerHighest
+                        : Colours.tPalette.m3surfaceContainerHigh
+                    Behavior on color { ColorAnimation { duration: 120 } }
+
+                    StateLayer {
+                        id: stateAnim2
+                        onClicked: Colours.wallpaperEnabled = !Colours.wallpaperEnabled
+                    }
+
+                    // Left Text Column
+                    Column {
+                        anchors.left: parent.left
+                        anchors.leftMargin: 14
+                        anchors.right: switchAnim2.left
+                        anchors.rightMargin: 8
+                        anchors.verticalCenter: parent.verticalCenter
+                        spacing: 1
+
+                        Text {
+                            width: parent.width
+                            text: "Dynamic Wallpaper"
+                            font.family: "Google Sans Flex"
+                            font.pointSize: 11
+                            font.weight: Font.Medium
+                            color: Colours.palette.m3onSurface
+                            elide: Text.ElideRight
+                        }
+
+                        Text {
+                            width: parent.width
+                            text: "Show synced wallpaper from caelestia"
+                            font.family: "Google Sans Flex"
+                            font.pointSize: 8
+                            color: Colours.palette.m3outline
+                            elide: Text.ElideRight
+                        }
+                    }
+
+                    // M3 Switch with Check/Cross Icon (Strictly Far Right)
+                    Rectangle {
+                        id: switchAnim2
+                        anchors.right: parent.right
+                        anchors.rightMargin: 14
+                        anchors.verticalCenter: parent.verticalCenter
+                        implicitWidth: 42
+                        implicitHeight: 24
+                        radius: 12
+                        color: Colours.wallpaperEnabled
+                            ? Colours.palette.m3primary
+                            : Colours.tPalette.m3surfaceContainerHighest
+                        Behavior on color { ColorAnimation { duration: 150 } }
+
+                        Rectangle {
+                            id: thumbAnim2
+                            width: 18
+                            height: 18
+                            radius: 9
+                            anchors.verticalCenter: parent.verticalCenter
+                            x: Colours.wallpaperEnabled ? parent.width - width - 3 : 3
+                            color: Colours.wallpaperEnabled ? Colours.palette.m3onPrimary : Colours.palette.m3outline
+                            Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
+
+                            MaterialIcon {
+                                anchors.centerIn: parent
+                                text: Colours.wallpaperEnabled ? "check" : "close"
+                                fontStyle.pointSize: 11
+                                color: Colours.wallpaperEnabled
+                                    ? Colours.palette.m3primary
+                                    : Colours.palette.m3surfaceContainerHigh
+                            }
+                        }
+                    }
+                }
+
                 // ── Row 5: Skip Clock Screen (Last in Appearance Group) ────
                 Rectangle {
                     id: rowSkipClock

--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -274,6 +274,65 @@ bool mkdirs(const std::string& path) {
     return true;
 }
 
+int copyWallpaperFile(const std::string& source, const std::string& user, bool quiet = false) {
+    const std::string wallpaperDir = "/var/cache/astra-airlock/wallpapers";
+
+    if (!isFile(source)) {
+        if (!quiet) {
+            std::fprintf(stderr, "astra-airlock: '%s' is not a readable regular file\n", source.c_str());
+        }
+        return 1;
+    }
+    if (!mkdirs(wallpaperDir)) {
+        std::fprintf(stderr, "astra-airlock: could not create '%s'\n", wallpaperDir.c_str());
+        return 1;
+    }
+
+    const std::string dest = wallpaperDir + "/" + user;
+
+    std::ifstream in(source, std::ios::binary);
+    std::ofstream out(dest, std::ios::binary | std::ios::trunc);
+    if (!in || !out) {
+        std::fprintf(stderr, "astra-airlock: could not write '%s'\n", dest.c_str());
+        return 1;
+    }
+    out << in.rdbuf();
+    out.close();
+    if (!out) {
+        std::fprintf(stderr, "astra-airlock: write to '%s' failed\n", dest.c_str());
+        return 1;
+    }
+    ::chmod(dest.c_str(), 0644);
+
+    if (!quiet) {
+        std::printf("astra-airlock: set wallpaper for '%s' from '%s'\n", user.c_str(), source.c_str());
+    }
+    return 0;
+}
+
+int setWallpaper(std::string source, const std::string& user) {
+    if (source.empty()) {
+        std::fprintf(stderr, "astra-airlock: --set-wallpaper requires a file path\n");
+        return 1;
+    }
+    if (user.empty()) {
+        std::fprintf(stderr, "astra-airlock: could not determine user name\n");
+        return 1;
+    }
+
+    std::string home;
+    if (const char* sudo = std::getenv("SUDO_USER"); sudo != nullptr && *sudo != '\0') {
+        if (struct passwd* pw = ::getpwnam(sudo); pw != nullptr && pw->pw_dir != nullptr) {
+            home = pw->pw_dir;
+        }
+    } else if (const char* h = std::getenv("HOME"); h != nullptr) {
+        home = h;
+    }
+    source = expandPath(std::move(source), home.empty() ? "/home/" + user : home);
+
+    return copyWallpaperFile(source, user, /*quiet=*/false);
+}
+
 // Sets the profile picture for `user` by copying `source` into the shared
 // avatar store.
 int setPfp(std::string source, const std::string& user) {
@@ -455,6 +514,14 @@ int syncScheme() {
 
     std::printf("astra-airlock: synced dynamic scheme for user '%s' to %s/\n",
                 user.c_str(), dynamicDir.c_str());
+    
+    const std::string wallpaperSource = home + "/.local/state/caelestia/wallpaper/current";
+    if (isFile(wallpaperSource)) {
+        if (copyWallpaperFile(wallpaperSource, user, /*quiet=*/true) == 0) {
+            std::printf("astra-airlock: synced wallpaper for user '%s'\n", user.c_str());
+        }
+    }
+
     return 0;
 }
 
@@ -899,6 +966,11 @@ void printUsage() {
         "                           as the profile picture for the current user;\n"
         "                           run with sudo. ~ and $VAR are expanded.\n"
         "\n"
+        "  --set-wallpaper FILE      copy FILE into the shared wallpaper store\n"
+        "                           (/var/cache/astra-airlock/wallpapers/<user>)\n"
+        "                           as the wallpaper for the current user;\n"
+        "                           run with sudo. ~ and $VAR are expanded.\n"
+        "\n"
         "  --convert FILE | -c FILE  read monitor configurations from a Hyprland\n"
         "                           config (plain `monitor =` lines or Lua\n"
         "                           `hl.monitor({ ... })` blocks) and print the\n"
@@ -1139,6 +1211,8 @@ int main(int argc, char** argv) {
             return configureKiosk(takeValue());
         } else if (arg == "--set-pfp") {
             return setPfp(takeValue(), currentUser());
+        }else if (arg == "--set-wallpaper") {
+            return setWallpaper(takeValue(), currentUser());
         } else if (arg == "--convert" || arg == "-c") {
             return convertFile(takeValue());
         } else if (arg == "--only") {

--- a/modules/GreeterSurface.qml
+++ b/modules/GreeterSurface.qml
@@ -39,6 +39,17 @@ Rectangle {
         root.exitRequested();
     }
 
+    property string imageSource: "/var/cache/astra-airlock/wallpapers/" + Colours.currentUser
+    onImageSourceChanged: {
+        if (wallpaper.active) {
+            wallpaper.active = false;
+            wallpaperTop.source = imageSource;
+        } else {
+            wallpaper.active = true;
+            wallpaper.source = imageSource;
+        }
+    }
+
     Image {
         id: wallpaper
         anchors.fill: parent
@@ -48,12 +59,6 @@ Rectangle {
         opacity: root.wallpaperEnabled ? 1 : 0
         scale: root.panelVisible ? 1 : 1.02
         property bool active: true
-        onSourceChanged: {
-            if (active) {
-                active = false;
-                Qt.callLater(() => { active = true; });
-            }
-        }
 
         Behavior on opacity { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
         Behavior on scale   { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }

--- a/modules/GreeterSurface.qml
+++ b/modules/GreeterSurface.qml
@@ -46,8 +46,48 @@ Rectangle {
         fillMode: Image.PreserveAspectCrop
         visible: true
         opacity: root.wallpaperEnabled ? 1 : 0
+        scale: root.panelVisible ? 1 : 1.02
+        property bool active: true
+        onSourceChanged: {
+            if (active) {
+                active = false;
+                Qt.callLater(() => { active = true; });
+            }
+        }
 
         Behavior on opacity { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
+        Behavior on scale   { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            autoPaddingEnabled: false
+            blurEnabled: true
+            blur: root.panelVisible ? 0.7 : 0
+            blurMax: 54
+            blurMultiplier: 1.0
+            Behavior on blur { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
+        }
+    }
+
+    Image {
+        id: wallpaperTop
+        anchors.fill: parent
+        source: "/var/cache/astra-airlock/wallpapers/" + Colours.currentUser
+        fillMode: Image.PreserveAspectCrop
+        visible: true
+        opacity: root.wallpaperEnabled && !wallpaper.active ? 1 : 0
+        scale: root.panelVisible ? 1 : 1.02
+
+        Behavior on opacity { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
+        Behavior on scale   { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            autoPaddingEnabled: false
+            blurEnabled: true
+            blur: root.panelVisible ? 0.7 : 0
+            blurMax: 54
+            blurMultiplier: 1.0
+            Behavior on blur { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
+        }
     }
 
     // ── Background Layer (captured by BackdropBlur in modals) ────

--- a/modules/GreeterSurface.qml
+++ b/modules/GreeterSurface.qml
@@ -38,6 +38,13 @@ Rectangle {
         root.exitRequested();
     }
 
+    Image {
+        id: wallpaper
+        anchors.fill: parent
+        source: "/home/leith/.local/state/caelestia/wallpaper/current"
+        fillMode: Image.PreserveAspectCrop
+    }
+
     // ── Background Layer (captured by BackdropBlur in modals) ────
     Item {
         id: bgLayer

--- a/modules/GreeterSurface.qml
+++ b/modules/GreeterSurface.qml
@@ -21,6 +21,7 @@ Rectangle {
     color: Colours.palette.m3background
 
     property bool panelVisible: Colours.skipClockPage
+    property bool wallpaperEnabled: Colours.wallpaperEnabled
     property bool entered: false
 
     Component.onCompleted: {
@@ -41,8 +42,12 @@ Rectangle {
     Image {
         id: wallpaper
         anchors.fill: parent
-        source: "/home/leith/.local/state/caelestia/wallpaper/current"
+        source: "/var/cache/astra-airlock/wallpapers/" + Colours.currentUser
         fillMode: Image.PreserveAspectCrop
+        visible: true
+        opacity: root.wallpaperEnabled ? 1 : 0
+
+        Behavior on opacity { NumberAnimation { duration: 500; easing.type: Easing.OutCubic } }
     }
 
     // ── Background Layer (captured by BackdropBlur in modals) ────

--- a/modules/GreeterSurface.qml
+++ b/modules/GreeterSurface.qml
@@ -55,7 +55,7 @@ Rectangle {
         anchors.fill: parent
         source: "/var/cache/astra-airlock/wallpapers/" + Colours.currentUser
         fillMode: Image.PreserveAspectCrop
-        visible: true
+        visible: root.enabled
         opacity: root.wallpaperEnabled ? 1 : 0
         scale: root.panelVisible ? 1 : 1.02
         property bool active: true

--- a/plugin/src/greeterstate.cpp
+++ b/plugin/src/greeterstate.cpp
@@ -307,6 +307,7 @@ void GreeterState::reload()
 {
     loadFromDisk();
     emit use12HourChanged();
+    emit wallpaperEnabledChanged();
     emit avatarShapeChanged();
     emit avatarShapeNameChanged();
     emit lavaLampEnabledChanged();

--- a/plugin/src/greeterstate.cpp
+++ b/plugin/src/greeterstate.cpp
@@ -90,6 +90,7 @@ void GreeterState::setActiveUser(const QString &user)
     if (!m_activeUser.isEmpty()) {
         QJsonObject cur;
         cur[QStringLiteral("use12Hour")] = m_use12Hour;
+        cur[QStringLiteral("wallpaperEnabled")] = m_wallpaperEnabled;
         cur[QStringLiteral("avatarShape")] = m_avatarShape;
         cur[QStringLiteral("avatarShapeName")] = m_avatarShapeName;
         cur[QStringLiteral("lavaLampEnabled")] = m_lavaLampEnabled;
@@ -105,6 +106,7 @@ void GreeterState::setActiveUser(const QString &user)
     if (m_userSettings.contains(user)) {
         QJsonObject u = m_userSettings.value(user).toObject();
         if (u.contains(QStringLiteral("use12Hour"))) m_use12Hour = u.value(QStringLiteral("use12Hour")).toBool(m_use12Hour);
+        if (u.contains(QStringLiteral("wallpaperEnabled"))) m_wallpaperEnabled = u.value(QStringLiteral("wallpaperEnabled")).toBool(m_wallpaperEnabled);
         if (u.contains(QStringLiteral("avatarShape"))) m_avatarShape = u.value(QStringLiteral("avatarShape")).toInt(m_avatarShape);
         if (u.contains(QStringLiteral("avatarShapeName"))) m_avatarShapeName = u.value(QStringLiteral("avatarShapeName")).toString(m_avatarShapeName);
         if (u.contains(QStringLiteral("lavaLampEnabled"))) m_lavaLampEnabled = u.value(QStringLiteral("lavaLampEnabled")).toBool(m_lavaLampEnabled);
@@ -132,6 +134,7 @@ void GreeterState::setActiveUser(const QString &user)
 
     emit activeUserChanged();
     emit use12HourChanged();
+    emit wallpaperEnabledChanged();
     emit avatarShapeChanged();
     emit avatarShapeNameChanged();
     emit lavaLampEnabledChanged();
@@ -179,6 +182,12 @@ void GreeterState::loadFromDisk()
         m_use12Hour = s.value(QStringLiteral("use12h")).toBool(m_use12Hour);
     }
 
+    if (s.contains(QStringLiteral("wallpaperEnabled"))) {
+        m_wallpaperEnabled = s.value(QStringLiteral("wallpaperEnabled")).toBool(m_wallpaperEnabled);
+    } else if (s.contains(QStringLiteral("wallpaper"))) {
+        m_wallpaperEnabled = s.value(QStringLiteral("wallpaper")).toBool(m_wallpaperEnabled);
+    }
+
     if (s.contains(QStringLiteral("avatarShape"))) {
         m_avatarShape = s.value(QStringLiteral("avatarShape")).toInt(m_avatarShape);
     }
@@ -216,6 +225,7 @@ void GreeterState::loadFromDisk()
         if (u.contains(QStringLiteral("schemeName"))) m_schemeName = u.value(QStringLiteral("schemeName")).toString(m_schemeName);
         if (u.contains(QStringLiteral("schemeFlavour"))) m_schemeFlavour = u.value(QStringLiteral("schemeFlavour")).toString(m_schemeFlavour);
         if (u.contains(QStringLiteral("schemeMode"))) m_schemeMode = u.value(QStringLiteral("schemeMode")).toString(m_schemeMode);
+        if (u.contains(QStringLiteral("wallpaperEnabled"))) m_wallpaperEnabled = u.value(QStringLiteral("wallpaperEnabled")).toBool(m_wallpaperEnabled);
     }
 
     // Fallback if dynamic scheme is selected but active user has no dynamic scheme on disk
@@ -243,6 +253,7 @@ void GreeterState::save()
     if (!m_activeUser.isEmpty()) {
         QJsonObject cur;
         cur[QStringLiteral("use12Hour")] = m_use12Hour;
+        cur[QStringLiteral("wallpaperEnabled")] = m_wallpaperEnabled;
         cur[QStringLiteral("avatarShape")] = m_avatarShape;
         cur[QStringLiteral("avatarShapeName")] = m_avatarShapeName;
         cur[QStringLiteral("lavaLampEnabled")] = m_lavaLampEnabled;
@@ -270,6 +281,7 @@ void GreeterState::save()
     s[QStringLiteral("schemeName")] = m_schemeName;
     s[QStringLiteral("schemeFlavour")] = m_schemeFlavour;
     s[QStringLiteral("schemeMode")] = m_schemeMode;
+    s[QStringLiteral("wallpaperEnabled")] = m_wallpaperEnabled;
 
     root[QStringLiteral("settings")] = s;
 
@@ -334,6 +346,14 @@ void GreeterState::setLavaLampEnabled(bool v)
     if (m_lavaLampEnabled == v) return;
     m_lavaLampEnabled = v;
     emit lavaLampEnabledChanged();
+    save();
+}
+
+void GreeterState::setWallpaperEnabled(bool v)
+{
+    if (m_wallpaperEnabled == v) return;
+    m_wallpaperEnabled = v;
+    emit wallpaperEnabledChanged();
     save();
 }
 

--- a/plugin/src/greeterstate.hpp
+++ b/plugin/src/greeterstate.hpp
@@ -20,6 +20,7 @@ class GreeterState : public QObject {
 
     Q_PROPERTY(QString activeUser READ activeUser WRITE setActiveUser NOTIFY activeUserChanged)
     Q_PROPERTY(bool use12Hour READ use12Hour WRITE setUse12Hour NOTIFY use12HourChanged)
+    Q_PROPERTY(bool wallpaperEnabled READ wallpaperEnabled WRITE setWallpaperEnabled NOTIFY wallpaperEnabledChanged)
     Q_PROPERTY(int avatarShape READ avatarShape WRITE setAvatarShape NOTIFY avatarShapeChanged)
     Q_PROPERTY(QString avatarShapeName READ avatarShapeName WRITE setAvatarShapeName NOTIFY avatarShapeNameChanged)
     Q_PROPERTY(bool lavaLampEnabled READ lavaLampEnabled WRITE setLavaLampEnabled NOTIFY lavaLampEnabledChanged)

--- a/plugin/src/greeterstate.hpp
+++ b/plugin/src/greeterstate.hpp
@@ -52,6 +52,9 @@ public:
     bool use12Hour() const { return m_use12Hour; }
     void setUse12Hour(bool v);
 
+    bool wallpaperEnabled() const { return m_wallpaperEnabled; }
+    void setWallpaperEnabled(bool v);
+
     int avatarShape() const { return m_avatarShape; }
     void setAvatarShape(int v);
 
@@ -88,6 +91,7 @@ public:
 signals:
     void activeUserChanged();
     void use12HourChanged();
+    void wallpaperEnabledChanged();
     void avatarShapeChanged();
     void avatarShapeNameChanged();
     void lavaLampEnabledChanged();
@@ -103,6 +107,7 @@ private:
 
     QString m_activeUser;
     bool m_use12Hour{false};
+    bool m_wallpaperEnabled{true};
     int m_avatarShape{19}; // Default Cookie9Sided
     QString m_avatarShapeName{QStringLiteral("Cookie 9-Sided")};
     bool m_lavaLampEnabled{true};

--- a/services/Colours.qml
+++ b/services/Colours.qml
@@ -50,6 +50,7 @@ Singleton {
             root.flavour = GreeterState.schemeFlavour;
             root._mode = GreeterState.schemeMode;
             root.use12Hour = GreeterState.use12Hour;
+            root.wallpaperEnabled = GreeterState.wallpaperEnabled;
             root.lavaLampEnabled = GreeterState.lavaLampEnabled;
             root.skipClockPage = GreeterState.skipClockPage;
             root.avatarShape = GreeterState.avatarShape;
@@ -61,6 +62,7 @@ Singleton {
     // Greeter-specific persisted settings
     property bool use12Hour: GreeterState.use12Hour
     property bool lavaLampEnabled: GreeterState.lavaLampEnabled
+    property bool wallpaperEnabled: GreeterState.wallpaperEnabled
     property bool skipClockPage: GreeterState.skipClockPage
     property int avatarShape: GreeterState.avatarShape
     property string avatarShapeName: GreeterState.avatarShapeName
@@ -74,6 +76,12 @@ Singleton {
         if (GreeterState.use12Hour !== use12Hour)
             GreeterState.use12Hour = use12Hour;
     }
+
+    onWallpaperEnabledChanged: {
+        if (GreeterState.wallpaperEnabled !== wallpaperEnabled)
+            GreeterState.wallpaperEnabled = wallpaperEnabled;
+    }
+
     onLavaLampEnabledChanged: {
         if (GreeterState.lavaLampEnabled !== lavaLampEnabled)
             GreeterState.lavaLampEnabled = lavaLampEnabled;

--- a/services/Colours.qml
+++ b/services/Colours.qml
@@ -19,6 +19,7 @@ Singleton {
     property string schemeName: GreeterState.schemeName || "caelestia"
     property string flavour: GreeterState.schemeFlavour || "default"
     property string variant: "tonalspot"
+    property string currentUser: UserDiscovery.currentUser || ""
 
     // Sync with GreeterState changes (e.g. from file reloads)
     Connections {


### PR DESCRIPTION
## What this changes

This adds Wallpaper support for cli and in the greeter itself

## Why

Wallpapers look good and would imo improve the overall look, it is deactivated by default and can be enabled by the user

## How it was verified

<!--
What you actually did, not "works for me". If you could not verify part of it, say which part
and why — that is useful, not a weakness.
-->
Wallpapers now get synced too in --sync, it places the file similar to the avatar in the wallpapers/ directory.
Dynamic Wallpapers can be activated in the settings panel
Wallpapers crossfade if you switch your user
Cool animation on menu opening and blur too
All those are useful mainly for the aspect of looks, tho its everyones own opinion if they want a wallpaper thats why its deactivated by default.
I built it manually and tested it normally by restarting i didnt notice bugs but if you find some please tell me so i can fix them, and anything else i should change just hit me up.  


<!--
Before opening:

- Rebased on current main and built it there.
- Debugging removed: commented-out lines, properties flipped to test something, timers added
  to reproduce a bug.
- Checked it against a real greetd session, not only a nested compositor, if the change
  touches authentication or session launching.
- Unrelated changes left out, or explained in one sentence if they had to come along.
-->
